### PR TITLE
Amount to wrap integration test

### DIFF
--- a/contracts/governed_token_wrapper/lib.rs
+++ b/contracts/governed_token_wrapper/lib.rs
@@ -687,7 +687,8 @@ pub mod governed_token_wrapper {
         /// Calculates the fee to be sent to fee recipient
         ///
         /// * `amount_to_wrap` - The amount to wrap
-        fn get_fee_from_amount(&mut self, amount_to_wrap: Balance) -> Balance {
+        #[ink(message)]
+        pub fn get_fee_from_amount(&mut self, amount_to_wrap: Balance) -> Balance {
             amount_to_wrap
                 .saturating_mul(self.fee_percentage)
                 .saturating_div(100)

--- a/tests/governed_token_wrapper/tokenWrapper.test.ts
+++ b/tests/governed_token_wrapper/tokenWrapper.test.ts
@@ -193,6 +193,20 @@ describe("token-wrapper", () => {
     };
   }
 
+  it.only("Get Wrapping Fee", async () => {
+    
+      let getFeeFromAmount = await tokenWrapperContract.tx.getFeeFromAmount(
+        1500
+      );
+
+      expect(getFeeFromAmount).to.be.ok;
+
+      expect(Number(getFeeFromAmount.output)).to.not.equal(0);
+
+      console.log(`amount is ${Number(getFeeFromAmount.output)}`);
+
+  });
+
   it("Add token address", async () => {
     expect(
       await tokenWrapperContract.tx.addTokenAddress(

--- a/tests/governed_token_wrapper/tokenWrapper.test.ts
+++ b/tests/governed_token_wrapper/tokenWrapper.test.ts
@@ -195,16 +195,20 @@ describe("token-wrapper", () => {
 
   it.only("Get Wrapping Fee", async () => {
     
-      let getFeeFromAmount = await tokenWrapperContract.tx.getFeeFromAmount(
+      let getFeeFromAmount = await tokenWrapperContract.query.getFeeFromAmount(
         1500
       );
 
-      expect(getFeeFromAmount).to.be.ok;
-
       expect(Number(getFeeFromAmount.output)).to.not.equal(0);
+  });
 
-      console.log(`amount is ${Number(getFeeFromAmount.output)}`);
+  it.only("Get Amount to Wrap", async () => {
+    
+      let getAmountToWrap = await tokenWrapperContract.query.getAmountToWrap(
+        2500
+      );
 
+      expect(Number(JSON.parse(getAmountToWrap.output).ok) != 0);
   });
 
   it("Add token address", async () => {

--- a/tests/governed_token_wrapper/tokenWrapper.test.ts
+++ b/tests/governed_token_wrapper/tokenWrapper.test.ts
@@ -3,7 +3,7 @@ import { artifacts, network, patract } from "redspot";
 import BN from "bn.js";
 import { all } from "@polkadot/api-derive/balances";
 import { hexToU8a } from "@polkadot/util";
-import {startContractNode} from "../util";
+import { startContractNode } from "../util";
 
 const { getContractFactory, getRandomSigner } = patract;
 const { api, getAddresses, getSigners } = network;
@@ -194,21 +194,19 @@ describe("token-wrapper", () => {
   }
 
   it.only("Get Wrapping Fee", async () => {
-    
-      let getFeeFromAmount = await tokenWrapperContract.query.getFeeFromAmount(
-        1500
-      );
+    let getFeeFromAmount = await tokenWrapperContract.query.getFeeFromAmount(
+      1500
+    );
 
-      expect(Number(getFeeFromAmount.output)).to.not.equal(0);
+    expect(Number(getFeeFromAmount.output) != 0);
   });
 
   it.only("Get Amount to Wrap", async () => {
-    
-      let getAmountToWrap = await tokenWrapperContract.query.getAmountToWrap(
-        2500
-      );
+    let getAmountToWrap = await tokenWrapperContract.query.getAmountToWrap(
+      2500
+    );
 
-      expect(Number(JSON.parse(getAmountToWrap.output).ok) != 0);
+    expect(Number(JSON.parse(getAmountToWrap.output).ok) != 0);
   });
 
   it("Add token address", async () => {

--- a/tests/governed_token_wrapper/tokenWrapper.test.ts
+++ b/tests/governed_token_wrapper/tokenWrapper.test.ts
@@ -193,7 +193,7 @@ describe("token-wrapper", () => {
     };
   }
 
-  it.only("Get Wrapping Fee", async () => {
+  it("Get Wrapping Fee", async () => {
     let getFeeFromAmount = await tokenWrapperContract.query.getFeeFromAmount(
       1500
     );
@@ -201,7 +201,7 @@ describe("token-wrapper", () => {
     expect(Number(getFeeFromAmount.output) != 0);
   });
 
-  it.only("Get Amount to Wrap", async () => {
+  it("Get Amount to Wrap", async () => {
     let getAmountToWrap = await tokenWrapperContract.query.getAmountToWrap(
       2500
     );

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -1,6 +1,6 @@
 import { ChildProcess, spawn } from "child_process";
 
-const substrateContractNodePath = "/Users/banks/Desktop/Projects/webb/substrate-contracts-node/target/release/substrate-contracts-node";
+const substrateContractNodePath = "./substrate-contracts-node";
 export async function startContractNode() {
   const startArgs: string[] = [];
   startArgs.push("--dev", "--tmp", "-lerror,runtime::contracts=debug");

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -1,6 +1,6 @@
 import { ChildProcess, spawn } from "child_process";
 
-const substrateContractNodePath = "./substrate-contracts-node";
+const substrateContractNodePath = "/Users/banks/Desktop/Projects/webb/substrate-contracts-node/target/release/substrate-contracts-node";
 export async function startContractNode() {
   const startArgs: string[] = [];
   startArgs.push("--dev", "--tmp", "-lerror,runtime::contracts=debug");


### PR DESCRIPTION
### Task 

> In the Token wrapper contract, we need to do the following:
>> Identify the normal units of the psp22 token
>> Integration test for getting amount to wrap

In partial resolution of https://github.com/webb-tools/protocol-ink/issues/38.

#### What this PR does

- Adds an integration test for `get_amount_to_wrap`
- Adds an integration test for `get_fee_from_amount`
